### PR TITLE
エラーハンドリングの修正

### DIFF
--- a/laravel_vue/Makefile
+++ b/laravel_vue/Makefile
@@ -25,3 +25,6 @@ build:
 # mysqlコンテナにアクセス
 mysql:
 	docker-compose -f ./laradock/docker-compose.yml exec mysql bash
+# テスト実行
+test:
+	docker-compose -f ./laradock/docker-compose.yml exec --user=laradock workspace php artisan test

--- a/laravel_vue/src/.php-cs-fixer.dist.php
+++ b/laravel_vue/src/.php-cs-fixer.dist.php
@@ -61,7 +61,7 @@ return $config
                 'if',
                 'return',
                 'switch',
-                // 'throw',
+                'throw',
                 'try',
             ]
         ],

--- a/laravel_vue/src/app/ApplicationServices/AuthApplicationService.php
+++ b/laravel_vue/src/app/ApplicationServices/AuthApplicationService.php
@@ -10,8 +10,6 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
-use RuntimeException;
-use Throwable;
 
 class AuthApplicationService implements AuthApplicationServiceInterface
 {
@@ -35,23 +33,18 @@ class AuthApplicationService implements AuthApplicationServiceInterface
      *
      * @param array $input
      * @return User
-     * @throws RuntimeException
      */
     public function register(array $input): User
     {
         $input['password'] = Hash::make($input['password']);
 
-        try {
-            $user = DB::transaction(function () use ($input) {
-                $user = $this->user_repository->create($input);
-
-                return $user;
-            });
+        $user = DB::transaction(function () use ($input) {
+            $user = $this->user_repository->create($input);
 
             return $user;
-        } catch (Throwable $e) {
-            throw new RuntimeException();
-        }
+        });
+
+        return $user;
     }
 
     /**

--- a/laravel_vue/src/app/ApplicationServices/AuthApplicationServiceInterface.php
+++ b/laravel_vue/src/app/ApplicationServices/AuthApplicationServiceInterface.php
@@ -6,7 +6,6 @@ namespace App\ApplicationServices;
 
 use App\Models\User;
 use Illuminate\Auth\AuthenticationException;
-use RuntimeException;
 
 interface AuthApplicationServiceInterface
 {
@@ -15,7 +14,6 @@ interface AuthApplicationServiceInterface
      *
      * @param array $input
      * @return User
-     * @throws RuntimeException
      */
     public function register(array $input): User;
 

--- a/laravel_vue/src/app/ApplicationServices/TodoApplicationService.php
+++ b/laravel_vue/src/app/ApplicationServices/TodoApplicationService.php
@@ -7,9 +7,6 @@ namespace App\ApplicationServices;
 use App\Repositories\TodoRepositoryInterface;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
-use RuntimeException;
-use Throwable;
 
 class TodoApplicationService implements TodoApplicationServiceInterface
 {
@@ -45,18 +42,11 @@ class TodoApplicationService implements TodoApplicationServiceInterface
      *
      * @param array $input
      * @return void
-     * @throws RuntimeException
      */
     public function create(array $input): void
     {
-        try {
-            DB::transaction(function () use ($input) {
-                $this->todo_repository->create($input);
-            });
-        } catch (Throwable $e) {
-            Log::error((string)$e);
-
-            throw new RuntimeException();
-        }
+        DB::transaction(function () use ($input) {
+            $this->todo_repository->create($input);
+        });
     }
 }

--- a/laravel_vue/src/app/ApplicationServices/TodoApplicationServiceInterface.php
+++ b/laravel_vue/src/app/ApplicationServices/TodoApplicationServiceInterface.php
@@ -20,7 +20,6 @@ interface TodoApplicationServiceInterface
      *
      * @param array $input
      * @return void
-     * @throws RuntimeException
      */
     public function create(array $input): void;
 }

--- a/laravel_vue/src/app/Http/Controllers/Admin/AuthController.php
+++ b/laravel_vue/src/app/Http/Controllers/Admin/AuthController.php
@@ -11,6 +11,7 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
 
 class AuthController extends Controller
 {
@@ -48,6 +49,8 @@ class AuthController extends Controller
                 'admin' => $admin,
             ]);
         } catch (AuthenticationException $e) {
+            Log::error((string)$e);
+
             return response()->json([
                 'message' => __('auth.failed'),
             ], Response::HTTP_UNAUTHORIZED);

--- a/laravel_vue/src/app/Http/Controllers/AuthController.php
+++ b/laravel_vue/src/app/Http/Controllers/AuthController.php
@@ -12,7 +12,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
-use RuntimeException;
 use Throwable;
 
 class AuthController extends Controller
@@ -49,8 +48,9 @@ class AuthController extends Controller
         try {
             $user = $this->auth_service->register($input);
         } catch (Throwable $e) {
-            Log::error($e->getMessage());
-            throw new RuntimeException($e->getMessage());
+            Log::error((string)$e);
+
+            throw $e;
         }
 
         return response()->json([
@@ -77,6 +77,8 @@ class AuthController extends Controller
                 'user' => $user,
             ]);
         } catch (AuthenticationException $e) {
+            Log::error((string)$e);
+
             return response()->json([
                 'message' => $e->getMessage(),
             ], Response::HTTP_UNAUTHORIZED);
@@ -92,6 +94,8 @@ class AuthController extends Controller
     public function logout(Request $request): JsonResponse
     {
         $this->auth_service->logout();
+
+        $request->session()->regenerate();
 
         return response()->json([], Response::HTTP_NO_CONTENT);
     }

--- a/laravel_vue/src/app/Http/Controllers/MobileAuthController.php
+++ b/laravel_vue/src/app/Http/Controllers/MobileAuthController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 class MobileAuthController extends Controller
@@ -24,9 +25,15 @@ class MobileAuthController extends Controller
     public function register(RegisterRequest $request): JsonResponse
     {
         $input = $request->only(['name', 'email', 'password']);
-
         $input['password'] = Hash::make($input['password']);
-        User::create($input);
+
+        try {
+            User::create($input);
+        } catch (Throwable $e) {
+            Log::error((string)$e);
+
+            throw $e;
+        }
 
         return response()->json([], Response::HTTP_CREATED);
     }
@@ -67,6 +74,8 @@ class MobileAuthController extends Controller
             $user = User::where('email', $request->input('email'))->first();
             $user->tokens()->delete();
         } catch (Throwable $e) {
+            Log::error((string)$e);
+
             throw $e;
         }
 

--- a/laravel_vue/src/app/Http/Controllers/TodoController.php
+++ b/laravel_vue/src/app/Http/Controllers/TodoController.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
 use App\Models\Todo;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class TodoController extends Controller
 {
@@ -32,11 +35,18 @@ class TodoController extends Controller
      */
     public function store(Request $request): JsonResponse
     {
-        $todo = new Todo();
-        $todo->fill($request->all())->save();
+        try {
+            $todo = new Todo();
+            $todo->fill($request->all())->save();
+        } catch (Throwable $e) {
+            Log::error((string)$e);
+
+            throw $e;
+        }
 
         return response()->json(
-            [], 201
+            [],
+            Response::HTTP_CREATED
         );
     }
 
@@ -49,7 +59,13 @@ class TodoController extends Controller
      */
     public function update(Request $request, Todo $todo): JsonResponse
     {
-        $todo->fill($request->all())->update();
+        try {
+            $todo->fill($request->all())->update();
+        } catch (Throwable $e) {
+            Log::error((string)$e);
+
+            throw $e;
+        }
 
         return response()->json([
             'todo' => $todo
@@ -64,10 +80,17 @@ class TodoController extends Controller
      */
     public function destroy(Todo $todo): JsonResponse
     {
-        $todo->delete();
+        try {
+            $todo->delete();
+        } catch (Throwable $e) {
+            Log::error((string)$e);
+
+            throw $e;
+        }
 
         return response()->json(
-            [], 204
+            [],
+            Response::HTTP_NO_CONTENT
         );
     }
 }

--- a/laravel_vue/src/tests/Unit/ApplicationServices/AuthApplicationServiceTest.php
+++ b/laravel_vue/src/tests/Unit/ApplicationServices/AuthApplicationServiceTest.php
@@ -11,7 +11,6 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Mockery;
-use RuntimeException;
 use Tests\TestCase;
 
 class AuthApplicationServiceTest extends TestCase
@@ -88,46 +87,6 @@ class AuthApplicationServiceTest extends TestCase
         $this->assertInstanceOf(User::class, $user);
         $this->assertSame($expected_name, $user->name);
         $this->assertSame($expected_email, $user->email);
-    }
-
-    /**
-     * @return void
-     */
-    public function testRegisterRuntimeException(): void
-    {
-        // データ
-        $expected_name = 'ユーザー名';
-        $expected_email = 'test@exmaple.com';
-        $expected_password = 'password';
-
-        // モックの設定
-        $this->user_repository_mock->shouldReceive('create')
-            ->once()
-            ->with(Mockery::on(function ($actual) use ($expected_name, $expected_email, $expected_password) {
-                $this->assertSame($expected_name, $actual['name']);
-                $this->assertSame($expected_email, $actual['email']);
-                $this->assertTrue(Hash::check($expected_password, $actual['password']));
-
-                return true;
-            }))
-            ->andThrow(RuntimeException::class);
-
-        $this->app->instance(UserRepositoryInterface::class, $this->user_repository_mock);
-
-        // インスタンス生成
-        $auth_application_service = $this->app->make(AuthApplicationServiceInterface::class);
-
-        // 検証
-        $this->expectException(RuntimeException::class);
-
-        // 実行
-        $auth_application_service->register(
-            [
-                'name' => $expected_name,
-                'email' => $expected_email,
-                'password' => $expected_password,
-            ]
-        );
     }
 
     /**

--- a/laravel_vue/src/tests/Unit/ApplicationServices/TodoApplicationServiceTest.php
+++ b/laravel_vue/src/tests/Unit/ApplicationServices/TodoApplicationServiceTest.php
@@ -11,7 +11,6 @@ use App\Models\Group;
 use App\Repositories\TodoRepositoryInterface;
 use Illuminate\Database\Eloquent\Collection;
 use Mockery;
-use RuntimeException;
 use Tests\TestCase;
 
 class TodoApplicationServiceTest extends TestCase
@@ -121,44 +120,5 @@ class TodoApplicationServiceTest extends TestCase
 
         // 検証
         $this->assertNull($actual);
-    }
-
-    /**
-     * @return void
-     */
-    public function testCreateRuntimeException(): void
-    {
-        // データ
-        $expected_title = "タイトル";
-        $expected_detail = "詳細です。";
-        $expected_user_id = 1;
-        $expected_group_id = 1;
-
-        // モックの設定
-        $this->todo_repository_mock->shouldReceive('create')
-            ->once()
-            ->with([
-                'title' => $expected_title,
-                'detail' => $expected_detail,
-                'user_id' => $expected_user_id,
-                'group_id' => $expected_group_id,
-            ])
-            ->andThrow(RuntimeException::class);
-
-        $this->app->instance(TodoRepositoryInterface::class, $this->todo_repository_mock);
-
-        // インスタンス生成
-        $this->todo_application_service = $this->app->make(TodoApplicationServiceInterface::class);
-
-        // 検証
-        $this->expectException(RuntimeException::class);
-
-        // 実行
-        $this->todo_application_service->create([
-            'title' => $expected_title,
-            'detail' => $expected_detail,
-            'user_id' => $expected_user_id,
-            'group_id' => $expected_group_id,
-        ]);
     }
 }


### PR DESCRIPTION
## 対象

- Vue.js/Laravel

## Issue

- Close #57 

## やったこと

- エラーハンドリングの修正
主にRepository層で予期せぬエラーが発生した時にRuntimeExceptionでキャッチし直していたが、予期せぬエラーは全てアクション層でThrowableとしてキャッチしてハンドラーに投げるように修正。
- makeコマンドの追加。
- php-cs-fixerの設定修正。
- ステータスコードのマジックナンバー修正。

## 備考

なし。
